### PR TITLE
Obfuscation of Non-Private Methods/Functions

### DIFF
--- a/src/Naneau/Obfuscator/Resources/services.yml
+++ b/src/Naneau/Obfuscator/Resources/services.yml
@@ -6,6 +6,9 @@ parameters:
     obfuscator.scramble_private_property.ignore: []
     obfuscator.scramble_use.ignore: []
 
+    # Tries to obfuscate everything (nonprivate methods) inclusive. This is prone to major issues and "private_method" should be renamed above to ignore all methods.
+    obfuscator.hammer: true,
+
     # Specific options for comment remover
     obfuscator.remove_comments.preserve_annotations: true
     obfuscator.remove_comments.annotations_flavor: "generic"
@@ -80,6 +83,7 @@ services:
             - @obfuscator.scrambler
         calls:
             - [addIgnore, [%obfuscator.scramble_private_method.ignore%]]
+            - [setHammerMode, [%obfuscator.hammer%]]
 
     # Scramble private properties
     obfuscator.node_visitor.scramble_private_property:

--- a/src/Naneau/Obfuscator/Resources/services.yml
+++ b/src/Naneau/Obfuscator/Resources/services.yml
@@ -7,7 +7,7 @@ parameters:
     obfuscator.scramble_use.ignore: []
 
     # Tries to obfuscate everything (nonprivate methods) inclusive. This is prone to major issues and "private_method" should be renamed above to ignore all methods.
-    obfuscator.hammer: true,
+    obfuscator.hammer: false,
 
     # Specific options for comment remover
     obfuscator.remove_comments.preserve_annotations: true

--- a/src/Naneau/Obfuscator/StringScrambler.php
+++ b/src/Naneau/Obfuscator/StringScrambler.php
@@ -39,6 +39,8 @@ class StringScrambler
             $this->setSalt(
                 md5(microtime(true) . rand(0,1))
             );
+        } else { 
+            $this->setSalt($salt);
         }
     }
 


### PR DESCRIPTION
Hello basilfx,

My marginal change here to your build adds support for "hammer mode" which attempts to obfuscate all function/method names, regardless of scoping. It works because of the single hash key (at least on single files), but I haven't deeply explored the edge cases where it falls apart. 

I don't know if you should merge this pull request, but as I am working on merging things back in to naneau's master as effectively as possible and this change took place on your branch, I figured it might be valuable to try to get our branches in sync. 

Entirely up to you, I'm not trying to impose unnecessary work on anyone here! If it isn't valuable to you, just toss this PR and I'll keep up my own branch.

Please let me know if you'd like me to to throw together any proof that it works or clean anything up to help with the merge. Right now, we still call the respective files "private method obfuscator" and whatnot even though now in hammer mode it might not be. 

Giuseppe.
